### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -711,7 +711,7 @@ to define rules/rule sets and enhance _detekt_ with your own flavor.
 Attention: You need a `resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider` file which 
 has as content the fully qualified name of your RuleSetProvider e.g. _io.gitlab.arturbosch.detekt.sampleruleset.SampleProvider_.
 
-The easiest way to define an rule set is to clone the provided detekt-sample-ruleset project.
+The easiest way to define a rule set is to clone the provided detekt-sample-ruleset project.
 
 Own rules have to extend the abstract _Rule_ class and override the `visitXXX` functions from the AST.
 A `RuleSetProvider` must be implemented which declares a `RuleSet` in the `instance` method.


### PR DESCRIPTION
"an rule" => "a rule"